### PR TITLE
Remove the Broken Slack Link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Additional Resources
 ### Community
 
 -  [Amazon Developer Forums](https://forums.developer.amazon.com/spaces/165/index.html) : Get help, help others.
--  [Alexa Community Slack](https://alexa.design/slack): Join the discussion in the **#apl** channel.
+
 
 ### Documentation
 


### PR DESCRIPTION
This link no longer works.  You get a page, "This link is no longer active"

*Issue #, if available:*

*Description of changes:*
The slack link (alexa.design/slack) no longer works :-(  So for now at least you can remove it (or update it).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
